### PR TITLE
Update 35-rules-desc.conf

### DIFF
--- a/Logstash-Configuration/etc/logstash/conf.d/35-rules-desc.conf
+++ b/Logstash-Configuration/etc/logstash/conf.d/35-rules-desc.conf
@@ -8,12 +8,12 @@ filter {
   if [observer][type] == "firewall" {
     if [rule][id] {
       translate {
-        field => "[rule][id]"
+        field => "[rule][ruleset]"
         destination => "[rule][alias]"
         dictionary_path => "/etc/logstash/conf.d/databases/rule-names.csv"
         refresh_interval => 60
         refresh_behaviour => replace
-        fallback => "%{[rule][id]}"
+        fallback => "%{[rule][ruleset]}"
       }
       mutate {
         add_field => { "[rule][description]" => "%{[interface][alias]}: %{[rule][alias]}" }


### PR DESCRIPTION
Amended `rule.id` to `rule.ruleset` 
This field was previously renamed within the GROK pattern, to conform to pfSense and ECS